### PR TITLE
Update on casing of TRUE, FALSE and NULL

### DIFF
--- a/Documentation/PhpFileFormatting/PhpSyntaxFormatting/Index.rst
+++ b/Documentation/PhpFileFormatting/PhpSyntaxFormatting/Index.rst
@@ -366,14 +366,14 @@ Booleans
 
 Booleans must use the language constructs of PHP and not explicit
 integer values like :code:`0` or :code:`1`. Furthermore they should be
-written in uppercase, i.e. :code:`TRUE` and :code:`FALSE`.
+written in lowercase, i.e. :code:`true` and :code:`false`.
 
 
 NULL
 """"
 
-Similarly this special value is written in uppercase, i.e.
-:code:`NULL`.
+Similarly this special value is written in lowercase, i.e.
+:code:`null`.
 
 
 Arrays


### PR DESCRIPTION
Since 7.6 TYPO3 used PSR-2 as code style. PSR-2 prescribes lowercase for booleans and null. In the TYPO3 core booleans and null are also lowercase.