### PR TITLE
Remove dummy container

### DIFF
--- a/Documentation/FileSystemConventions/Typo3DirectoryStructure/Index.rst
+++ b/Documentation/FileSystemConventions/Typo3DirectoryStructure/Index.rst
@@ -15,15 +15,6 @@ directories:
 .. container:: table-row
 
    Directory
-         Directory
-
-   Description
-         Description
-
-
-.. container:: table-row
-
-   Directory
          :code:`fileadmin/`
 
    Description


### PR DESCRIPTION
On the [TYPO3 directory structure page](https://docs.typo3.org/typo3cms/CodingGuidelinesReference/FileSystemConventions/Typo3DirectoryStructure/Index.html), the first container provides no useful information and is more confusing than helpful
![bildschirmfoto 2018-01-10 um 16 07 03](https://user-images.githubusercontent.com/1093360/34779400-592b1610-f620-11e7-97a1-0207e4c128ce.png)
